### PR TITLE
Fix build to deploy, update firebase tools, set platform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@
 #   | Jul 2021 | 16.5.0 | 7.19.1 |
 
 # Note: IF YOU CHANGE THIS, change the '-nodeXX' suffix within 'build' script.
-FROM node:18-alpine
+FROM --platform=linux/amd64 node:18-alpine
 
 # Version of 'firebase-tools' is also our version
 #

--- a/build
+++ b/build
@@ -17,12 +17,12 @@ set -eu -o pipefail
 #     -> https://github.com/firebase/firebase-tools/releases
 
 # Note: Keep the variable name, read by 'push-to-gcr'.
-_VERSION=11.0.1
+_VERSION=11.26.0
 
 _IMAGE_NAME=firebase-ci-builder
 
 # Note: '-nodeXY-npmZ' is NOT connected with what the base image in 'Dockerfile' provides. MAINTAIN MANUALLY!!!
-_TAG=${_VERSION}b-node18-npm8
+_TAG=${_VERSION}-node18-npm8
   # tbd. REMOVE 'b' in next version update
 
 docker build --pull --build-arg FIREBASE_VERSION=${_VERSION} . -t ${_IMAGE_NAME}:${_TAG}


### PR DESCRIPTION
# Summary
Found a small error where the _TAG variable was not matching between the build and push scripts.
In the build updated the firebase tools version to a recent version. Put in the platform flag on the FROM line of the Dockerfile to force to be `linux/amd64`. This is more of a convenience so that builds will work on Google Cloud Builds when the image is built on Apple Silicon. This avoids getting the message
```
exec /usr/local/bin/docker-entrypoint.sh: exec format error
```